### PR TITLE
View for Guests to Update RSVP Status

### DIFF
--- a/weddingbells/src/components/App/App.js
+++ b/weddingbells/src/components/App/App.js
@@ -12,7 +12,7 @@ import {
 	WeddingCreationView,
 	ProtectedView,
 	CouplePageView,
-	
+	WeddingInviteView,
 } from "../../views";
 
 import { toggleAuthModal } from "../../actions";
@@ -30,6 +30,11 @@ class App extends Component {
 						exact
 						path="/create-wedding"
 						render={() => <WeddingCreationView />}
+					/>
+					<Route
+						exact
+						path="/weddings/:weddingId/invite/:guestId"
+						component={WeddingInviteView}
 					/>
 					<PrivateRoute path="/protected" component={ProtectedView} />
 					<PrivateRoute path="/couple" component={CouplePageView} />

--- a/weddingbells/src/components/Container/Container.js
+++ b/weddingbells/src/components/Container/Container.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const Container = styled.div`
+	margin: 0 auto;
+	width: 100%;
+	max-width: 760px;
+`;
+
+export default Container;

--- a/weddingbells/src/components/GuestForm/index.js
+++ b/weddingbells/src/components/GuestForm/index.js
@@ -55,40 +55,7 @@ const GuestForm = () => {
 					/>
 				</Col>
 			</FormGroup>
-			<FormGroup row>
-				<Label for="is_going" sm={6}>
-					Are they going?
-				</Label>
-				<Col sm={5}>
-					<select name="is_going" ref={register({ required: true })}>
-						<option value="true">True</option>
-						<option value="false">False</option>
-					</select>
-				</Col>
-			</FormGroup>
-			<FormGroup row>
-				<Label for="has_responded" sm={6}>
-					Have they responded?
-				</Label>
-				<Col sm={5}>
-					<select name="has_responded" ref={register({ required: true })}>
-						<option value="true">true</option>
-						<option value="false">False</option>
-					</select>
-				</Col>
-			</FormGroup>
-			<FormGroup row>
-				<Label for="plus_one" sm={6}>
-					Are they bringing a plus one?
-				</Label>
-				<Col sm={5}>
-					<select name="plus_one" ref={register({ required: true })}>
-						<option value="true">True</option>
-						<option value="false">False</option>
-					</select>
-				</Col>
-			</FormGroup>
-			<input type="submit" />
+			<input type="submit" value="Invite Guest" />
 		</Form>
 	);
 };

--- a/weddingbells/src/components/GuestRSVPForm/GuestRSVPForm.js
+++ b/weddingbells/src/components/GuestRSVPForm/GuestRSVPForm.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { Radio } from "antd";
+import Container from "../../components/Container/Container";
+
+const GuestRSVPForm = ({ guest, handleGuestUpdates, handleOnSubmit }) => {
+	const { is_going, plus_one } = guest;
+	return (
+		<section className="rsvp">
+			<Container>
+				<form onSubmit={e => handleOnSubmit(e)}>
+					<div className="radio-group">
+						<p className="question">Will You Be Attending?</p>
+						<Radio.Group
+							name="is_going"
+							buttonStyle="solid"
+							onChange={handleGuestUpdates}
+						>
+							<Radio checked={is_going ? true : false} value="true">
+								Accepts with Pleasure
+							</Radio>
+							<Radio checked={is_going ? false : true} value="false">
+								Regretfully Declines
+							</Radio>
+						</Radio.Group>
+					</div>
+					<div className="radio-group">
+						<p className="question">Bringing a Plus-One?</p>
+						<Radio.Group
+							name="plus_one"
+							buttonStyle="solid"
+							disabled={is_going === false}
+							onChange={handleGuestUpdates}
+						>
+							<Radio checked={plus_one ? true : false} value="true">
+								Yes, Bringing a Plus-One
+							</Radio>
+							<Radio checked={plus_one ? false : true} value="false">
+								No, Attending Alone
+							</Radio>
+						</Radio.Group>
+					</div>
+					<input type="submit" value="Send RSVP" />
+				</form>
+			</Container>
+		</section>
+	);
+};
+
+export default GuestRSVPForm;

--- a/weddingbells/src/components/WeddingDetailsHero/WeddingDetailsHero.js
+++ b/weddingbells/src/components/WeddingDetailsHero/WeddingDetailsHero.js
@@ -1,0 +1,16 @@
+import React from "react";
+import Container from "../../components/Container/Container";
+
+const WeddingDetailsHero = ({ wedding }) => {
+	return (
+		<section className="hero">
+			<Container>
+				<h4>Save the Date!</h4>
+				<h1>{new Date(wedding.date).toDateString()}</h1>
+				<h2>{wedding.location}</h2>
+			</Container>
+		</section>
+	);
+};
+
+export default WeddingDetailsHero;

--- a/weddingbells/src/views/WeddingInviteView/WeddingInviteView.js
+++ b/weddingbells/src/views/WeddingInviteView/WeddingInviteView.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { withRouter } from "react-router-dom";
+import { Alert } from "antd";
+import axios from "axios";
+import "./WeddingIviteView.scss";
+
+import Container from "../../components/Container/Container";
+import WeddingDetailsHero from "../../components/WeddingDetailsHero/WeddingDetailsHero";
+import GuestRSVPForm from "../../components/GuestRSVPForm/GuestRSVPForm";
+
+const BACKEND_BASE_URL = process.env.REACT_APP_BACKEND_BASE_URL;
+
+const WeddingInviteView = props => {
+	const { weddingId, guestId } = props.match.params;
+	const [wedding, setWedding] = useState(null);
+	const [guest, setGuest] = useState(null);
+	const [status, setStatus] = useState(null);
+
+	const handleGuestUpdates = event => {
+		const updatedGuest = {
+			...guest,
+			[event.target.name]: event.target.value == "true",
+		};
+		setGuest(updatedGuest);
+	};
+
+	const handleOnSubmit = async event => {
+		event.preventDefault();
+		try {
+			await axios.put(
+				`${BACKEND_BASE_URL}/api/weddings/${wedding.id}/guests/${guest.id}`,
+				guest
+			);
+			setStatus("success");
+		} catch (error) {
+			setStatus("error");
+		}
+	};
+
+	useEffect(() => {
+		axios
+			.get(`${BACKEND_BASE_URL}/api/weddings/${weddingId}`)
+			.then(res => res.data)
+			.then(setWedding);
+		axios
+			.get(`${BACKEND_BASE_URL}/api/weddings/${weddingId}/guests/${guestId}`)
+			.then(res => res.data)
+			.then(setGuest);
+	}, []);
+
+	if (!wedding || !guest) return <p>Loading...</p>;
+	return (
+		<main className="weddinginvite-main">
+			<WeddingDetailsHero wedding={wedding} />
+			<GuestRSVPForm
+				guest={guest}
+				handleGuestUpdates={handleGuestUpdates}
+				handleOnSubmit={handleOnSubmit}
+			/>
+			<Container>
+				<Alert
+					closable
+					type={status}
+					style={{ display: status ? "block" : "none" }}
+					message={status === "success" ? "Success!" : "Error!"}
+					showIcon
+					description={
+						status === "success"
+							? "You're all set, thank you for RSVPing."
+							: "Oh no, an error occurred while trying to update your RSVP."
+					}
+					onClose={e => setStatus(null)}
+				/>
+			</Container>
+		</main>
+	);
+};
+
+export default withRouter(WeddingInviteView);

--- a/weddingbells/src/views/WeddingInviteView/WeddingIviteView.scss
+++ b/weddingbells/src/views/WeddingInviteView/WeddingIviteView.scss
@@ -1,0 +1,58 @@
+.weddinginvite-main {
+	margin: 0 auto;
+	height: 100%;
+	background-color: #f5f5f5;
+
+	.hero {
+		h1 {
+			font-size: 64px;
+			margin: 1rem 0 2rem;
+		}
+		h2 {
+			font-size: 44px;
+		}
+		h4 {
+			font-size: 42px;
+		}
+
+		& * {
+			color: white;
+		}
+
+		width: 100vw;
+		height: 75vh;
+
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+
+		background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+			url(https://images.unsplash.com/photo-1527529482837-4698179dc6ce?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9);
+		background-size: cover;
+		background-position: bottom center;
+		background-repeat: no-repeat;
+	}
+
+	.rsvp {
+		padding: 4rem 0 1rem;
+
+		& .radio-group {
+			margin: 0 0 2rem;
+			p.question {
+				margin-left: 2rem;
+				font-weight: bold;
+				text-align: left;
+			}
+
+			@media screen and (max-width: 600px) {
+				margin-left: 2rem;
+				text-align: left;
+
+				p.question {
+					margin-left: 0;
+				}
+			}
+		}
+	}
+}

--- a/weddingbells/src/views/index.js
+++ b/weddingbells/src/views/index.js
@@ -5,3 +5,4 @@ export { default as LandingPageView } from "./LandingPageView/LandingPageView";
 export { default as CouplePageView } from "./CouplePageView/CouplePageView";
 export { default as ProtectedView } from "./ProtectedView";
 export { default as WeddingCreationView } from "./WeddingCreationView/WeddingCreationView";
+export { default as WeddingInviteView } from "./WeddingInviteView/WeddingInviteView";


### PR DESCRIPTION
## Description

As part of our second release canvas, the goal is to email an invite to any guest manually added by the couples via their wedding page. This email acts as an invitation to that couple’s wedding and would include a link to manage the guest’s RSVP--allowing them to update their contact information (email), whether they are going, and if they are bringing a plus-one or not.

This PR creates the view necessary for Guests to update their RSVP status. It simply displays the wedding information at the top of the page as well as a form to update whether or not they're going and if they are bringing a plus-one or not.

This PR also goes in hand with lambda-school-labs/wedding-bells-be#48.

[See the design doc for more information.](https://docs.google.com/document/d/1RXCAtSNrdIb92PaHNJQgqsuzGmV4NUMhtf6Z-QcEL08/edit?usp=sharing)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
